### PR TITLE
[MAPA-63] - Hotfix therapist form

### DIFF
--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -58,7 +58,9 @@ from .address_search import (
     get_coordinates_via_google_api,
 )
 
-from msrs.models import Cities
+import logging
+
+logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 
 # Create your views here.
 form_steps = {
@@ -256,6 +258,7 @@ def index(request):
 def fill_step(request, type_form, step):
     # caso esteja logada
     # import ipdb; ipdb.set_trace();
+
     if request.user.is_authenticated:
         form_data = FormData.objects.get(user=request.user)
 
@@ -291,6 +294,7 @@ def fill_step(request, type_form, step):
         return HttpResponseRedirect(f"/{type_form}/1")
 
     # pega o form do passo acessado
+    logging.info(f"Type form: {type_form}, step: {step}")
     step_form = current_step(step, type_form)
 
     if not step_form:
@@ -410,7 +414,7 @@ def final_step(request, type_form):
             .replace(")", "")
             .replace("-", "")
         )
-       
+
         volunteer = Volunteer.objects.create(
             occupation=form_data.type_form,
             first_name=form_data.values["first_name"],

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -225,9 +225,6 @@ def current_step(step, type_form):
             form_step_2["fields"]["document_number"] = MaskField(
                 label="OAB", mask="000000"
             )
-        logging.info(
-            f"Type form: {type_form}, step: {step}, Label {form_step_2['fields']['document_number'].label}"
-        )
         return form_step_2
     elif step == 5:
         form_step_5 = form_steps.get(step)

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -291,7 +291,6 @@ def fill_step(request, type_form, step):
         return HttpResponseRedirect(f"/{type_form}/1")
 
     # pega o form do passo acessado
-    logging.info(f"Type form: {type_form}, step: {step}")
     step_form = current_step(step, type_form)
 
     if not step_form:

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -226,11 +226,14 @@ def current_step(step, type_form):
     if step == 2:
         if type_form == "psicologa":
             form_step_2 = form_steps.get(step)
-        else:
+        elif type_form == "advogada":
             form_step_2 = form_steps.get(step)
             form_step_2["fields"]["document_number"] = MaskField(
                 label="OAB", mask="000000"
             )
+        logging.info(
+            f"Type form: {type_form}, step: {step}, Label {form_step_2['fields']['document_number'].label}"
+        )
         return form_step_2
     elif step == 5:
         form_step_5 = form_steps.get(step)

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -58,9 +58,6 @@ from .address_search import (
     get_coordinates_via_google_api,
 )
 
-import logging
-
-logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 
 # Create your views here.
 form_steps = {

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -120,12 +120,6 @@ form_steps = {
                 error_messages={"min_length": "Por favor, insira o número completo."},
             ),
             "birth_date": DateField(label="Data de nascimento"),
-            "document_number": MaskField(
-                label="CRP",
-                mask="00/000000",
-                min_length=8,
-                error_messages={"min_length": "Por favor, insira o CRP completo."},
-            ),
         },
     },
     3: {
@@ -157,13 +151,7 @@ form_steps = {
     5: {
         "title": "Campo de atuação",
         "subtitle": "",
-        "fields": {
-            "fields_of_work": forms.MultipleChoiceField(
-                label="",
-                widget=forms.CheckboxSelectMultiple,
-                choices=FOW_THERAPIST_CHOICES,
-            )
-        },
+        "fields": {},
     },
     6: {
         "title": "Abordagem",
@@ -226,6 +214,12 @@ def current_step(step, type_form):
     if step == 2:
         if type_form == "psicologa":
             form_step_2 = form_steps.get(step)
+            form_step_2["fields"]["document_number"] = MaskField(
+                label="CRP",
+                mask="00/000000",
+                min_length=8,
+                error_messages={"min_length": "Por favor, insira o CRP completo."},
+            )
         elif type_form == "advogada":
             form_step_2 = form_steps.get(step)
             form_step_2["fields"]["document_number"] = MaskField(
@@ -242,6 +236,12 @@ def current_step(step, type_form):
                 label="",
                 widget=forms.CheckboxSelectMultiple,
                 choices=FOW_LAWYER_CHOICES,
+            )
+        elif type_form == "psicologa":
+            form_step_5["fields"]["fields_of_work"] = forms.MultipleChoiceField(
+                label="",
+                widget=forms.CheckboxSelectMultiple,
+                choices=FOW_THERAPIST_CHOICES,
             )
         return form_step_5
 


### PR DESCRIPTION
Conforme o teste realizado em 16/01 o cadastro está apresentando erros nas etapas mostrando informações de advogada. Atrávés de teste descobrimos que ao se cadastrar como advogada e depois voltar e se cadastrar como psicóloga as opções de advogada do form se mantinham. Assim,  removi os defaults de campos que estavam como de psicóloga para setar sempre que for escolhido passo. 